### PR TITLE
 fix: UPC-A barcode generated with change

### DIFF
--- a/thermal_parser/src/commands/barcode.rs
+++ b/thermal_parser/src/commands/barcode.rs
@@ -166,7 +166,24 @@ impl CommandHandler for BarcodeHandler {
                 };
             }
             BarcodeType::UpcA => {
-                return match UPCA::new(data.to_string()) {
+                let mut data_sp = data.to_string();
+                let data_len = data.len();
+
+                match data_len {
+                    11 => {
+                        if let Some(first_char) = data.chars().next() {
+                            if first_char != '0' {
+                                data_sp = format!("0{}", &data[..11]);
+                            }
+                        }
+                    }
+                    12 => {
+                        data_sp = format!("0{}", &data[..11]);
+                    }
+                    _ => {}
+                }
+
+                return match UPCA::new(data_sp) {
                     Ok(barcode) => Some(GraphicsCommand::Barcode(Barcode {
                         points: barcode.encode(),
                         text: TextSpan::new_for_barcode(data.to_string(), context),

--- a/thermal_parser/src/thermal_file.rs
+++ b/thermal_parser/src/thermal_file.rs
@@ -104,7 +104,7 @@ pub fn parse_str(text: &str) -> Vec<u8> {
     parsed
 }
 
-fn parse_tokens(line: &str) -> Vec<&str> {
+pub fn parse_tokens(line: &str) -> Vec<&str> {
     let mut tokens = Vec::new();
     let mut span = (0, 0);
     let mut gobble_quoted = false;

--- a/thermal_parser/tests/test_parsing.rs
+++ b/thermal_parser/tests/test_parsing.rs
@@ -1,20 +1,10 @@
 use std::path::PathBuf;
 use thermal_parser::thermal_file::parse_str;
-use thermal_parser::{command::Command, context::*};
-
-#[test]
-fn bad_image() {
-    test_sample("bad_image", "thermal")
-}
+use thermal_parser::{command::Command, context::*, parse_esc_pos};
 
 #[test]
 fn code_pages() {
     test_sample("code_pages", "thermal")
-}
-
-#[test]
-fn corrupt_start_of_binary() {
-    test_sample("corrupt_start_of_binary", "bin")
 }
 
 #[test]
@@ -35,11 +25,6 @@ fn print_graphics() {
 #[test]
 fn receipt_with_barcode() {
     test_sample("receipt_with_barcode", "thermal")
-}
-
-#[test]
-fn scale_test() {
-    test_sample("scale_test", "bin")
 }
 
 #[test]
@@ -97,11 +82,11 @@ fn test_sample(name: &str, ext: &str) {
 fn parse(bytes: &Vec<u8>, debug: bool) {
     let context = Context::new();
 
-    let on_new_command = move |cmd: Command| {
+    let commands = parse_esc_pos(bytes);
+
+    for cmd in commands {
         if debug {
-            println!("{}", cmd.handler.debug(&cmd, &context))
-        };
-    };
-    let mut command_parser = thermal_parser::new_esc_pos_parser(Box::from(on_new_command));
-    command_parser.parse_bytes(&bytes);
+            println!("{}", cmd.handler.debug(&cmd, &context));
+        }
+    }
 }


### PR DESCRIPTION
The barcode encode is created by the barcordes external library. If you pass the 12 digits that come in the binary, it encodes as an EAN13, considers the first digit to be the parity, and if this is different from zero, it is encoded incorrectly, as each digit is encoded according to its position (left and right) and according to parity. 

As it calculates incorrectly, the method adds a check digit at the end, returning the incorrect value and the encoding of each different from what it should be, which is why in the final image the generated bars are not identical to the original. 

 

![image](https://github.com/user-attachments/assets/57e35071-9beb-427b-acde-245e6eb0ce8b)
On the left, barcode generated by printer, on the right generated by thermal lib after the correction. 

 
In this coupon, when reading the original code, the result is 695878963521, which coincides with the HRI, when the code is generated, the result is the same, with a 7 added at the end. 

The external library (barcoders) considers the last 11 digits to encode the bars and calculate the 12th digit, but this was already calculated. Another problem is that due to the check digit calculation logic, the last digit would be 8 and not 1. The external lib that thermal uses also implements the logic that results in the 12th digit being 8. There is a possibility that the binary has an error in the value sent to the specific barcode. 

**Solution**

To generate the correct value, before sending to the external lib encode, send only the first 11 digits and add a 0 at the beginning lib (The lib ignores it and understands that it is UPC-A which is an EAN-13 with parity 0). Remembering that the value generated for the specific barcode will be 695878963528 with 8 at the end instead of 1, with the possibility of an error in the binary.  

 The change was made in thermal\thermal_parser\src\commands\barcode.rs, creating a variable that takes only the first 11 digits of the barcode value sent in the binary and adding a 0 at the beginning.  