### PR TITLE
fix: EAN 13 barcode is generated incorrectly

### DIFF
--- a/thermal_parser/src/commands/barcode.rs
+++ b/thermal_parser/src/commands/barcode.rs
@@ -154,7 +154,8 @@ impl CommandHandler for BarcodeHandler {
                 };
             }
             BarcodeType::Ean13 => {
-                return match EAN13::new(data.to_string()) {
+                let data_sp = &data[..12];
+                return match EAN13::new(data_sp.to_string()) {
                     Ok(barcode) => Some(GraphicsCommand::Barcode(Barcode {
                         points: barcode.encode(),
                         text: TextSpan::new_for_barcode(data.to_string(), context),


### PR DESCRIPTION
The complete EAN-13 type barcode has exactly 13 digits, where the first is the parity, a digit that decides what the thin and thick bars will be for the next 11 digits. And the last digit (13th) is the check digit, calculated as the sum of the first 12 mod 10. 

The barcodes.bin binary contains an EAN-13 barcode whose value in the binary is 4596979869696. In lib thermal, the barcode of this binary is encoded with another value. 

The cause of this problem is that the 13 digits are sent to an external barcodes lib to perform the encoding, which in turn considers the last 12 digits to encode the bars and calculate the 13th digit, but this was already calculated. 

Another problem is that due to the check digit calculation logic, the last digit would be 5 and not 6. The external lib that thermal uses also implements the logic that results in the 13th digit being 5. There is a possibility that the binary has an error in the value sent to the specific barcode. 

**Solution** 

To generate the correct value, before sending to the external lib encode, send only the first 12 digits. Remembering that the value generated for the specific barcode will be 4596979869695 with 5 at the end instead of 6, with the possibility of an error in the binary. 

The change was made in thermal\thermal_parser\src\commands\barcode.rs, creating a variable that takes only the first 12 digits of the barcode value sent in the binary. 