### PR TITLE
fix: CODE-128 barcode generates HRI with À

### DIFF
--- a/thermal_parser/src/commands/barcode.rs
+++ b/thermal_parser/src/commands/barcode.rs
@@ -154,7 +154,8 @@ impl CommandHandler for BarcodeHandler {
                 };
             }
             BarcodeType::Ean13 => {
-                return match EAN13::new(data.to_string()) {
+                let data_sp = &data[..12];
+                return match EAN13::new(data_sp.to_string()) {
                     Ok(barcode) => Some(GraphicsCommand::Barcode(Barcode {
                         points: barcode.encode(),
                         text: TextSpan::new_for_barcode(data.to_string(), context),

--- a/thermal_parser/src/commands/barcode.rs
+++ b/thermal_parser/src/commands/barcode.rs
@@ -99,10 +99,16 @@ impl CommandHandler for BarcodeHandler {
                     .replace("{B", "Ɓ")
                     .replace("{C", "Ć");
 
+                let hri_data: String = data
+                    .replace("{A", "A")
+                    .replace("{B", "B")
+                    .replace("{C", "C");
+
                 return match Code128::new(adjusted_data.to_string()) {
+
                     Ok(barcode) => Some(GraphicsCommand::Barcode(Barcode {
                         points: barcode.encode(),
-                        text: TextSpan::new_for_barcode(data.to_string(), context),
+                        text: TextSpan::new_for_barcode(hri_data.to_string(), context),
                         point_width,
                         point_height,
                         hri,


### PR DESCRIPTION
In the my bin file there is a CODE 128 type barcode, and the value of the barcode is {A4589696, with the thermal library the barcode is generated and when read its value is 4589696 and the HRI is the same as an À at the beginning, À4589696. 

![image](https://github.com/user-attachments/assets/461687e8-db53-4a67-81f0-5576ef67434d)

The CODE 128 barcode can represent all 128 ASCII code characters (numbers, upper/lower case letters, symbols and control codes. 

The starting character can be of three types: “CODE A”, “CODE B” and “CODE C”. The character type determines the character composition of subsequent characters. In the binary barcodes.bin there is a barcode displaying “À” before other characters in the HRI. 

In the binary code the value appears {A4589696: 

The “{“ indicates that it is an alphanumeric sequence in ASCII. 

The “A” indicates the type of code, which could be B or C as well. 

The remaining characters are the barcode value. 

In the thermal code, “{A” is replaced by “À”, “{B” by “Ɓ” and “{C” by “Ć”. And the code has the following comment: “//all code128 data has two bytes that set the type, we are converting this to the barcoders format”. If this conversion is not carried out, the barcode is not even generated. 

The correction was not to use the same variable used to code the bars in HRI, in addition to taking the original data, it already replaces it by removing “{A”, “{B” or “{C”, as it only needs to be in the system that generates the barcodes. File: thermal_parser/src/commands/barcode.rs.  

after the correction:

![image](https://github.com/user-attachments/assets/115a271a-aa22-4127-9aeb-2ffa5e887972)



 